### PR TITLE
Admin export

### DIFF
--- a/backend/blueprint.py
+++ b/backend/blueprint.py
@@ -37,8 +37,8 @@ repo = ExportRepository()
 """
     Configuration de l'admin
 """
-
-admin.add_view(ModelView(Export, DB.session))
+#FIXME: Error required fields
+#admin.add_view(ModelView(Export, DB.session))
 admin.add_view(ModelView(CorExportsRoles, DB.session))
 
 EXPORTS_DIR = os.path.join(current_app.static_folder, 'exports')

--- a/backend/blueprint.py
+++ b/backend/blueprint.py
@@ -37,8 +37,8 @@ repo = ExportRepository()
 """
     Configuration de l'admin
 """
-#FIXME: Error required fields
-#admin.add_view(ModelView(Export, DB.session))
+#FIX: remove init Export model
+admin.add_view(ModelView(Export, DB.session))
 admin.add_view(ModelView(CorExportsRoles, DB.session))
 
 EXPORTS_DIR = os.path.join(current_app.static_folder, 'exports')

--- a/backend/blueprint.py
+++ b/backend/blueprint.py
@@ -20,6 +20,10 @@ from geonature.core.gn_permissions import decorators as permissions
 
 from .repositories import ExportRepository, EmptyDataSetError
 
+from flask_admin.contrib.sqla import ModelView
+from .models import Export, CorExportsRoles
+from pypnnomenclature.admin import admin
+from geonature.utils.env import DB
 
 logger = current_app.logger
 logger.setLevel(logging.DEBUG)
@@ -29,6 +33,13 @@ logger.setLevel(logging.DEBUG)
 blueprint = Blueprint('exports', __name__)
 repo = ExportRepository()
 
+
+"""
+    Configuration de l'admin
+"""
+
+admin.add_view(ModelView(Export, DB.session))
+admin.add_view(ModelView(CorExportsRoles, DB.session))
 
 EXPORTS_DIR = os.path.join(current_app.static_folder, 'exports')
 os.makedirs(EXPORTS_DIR, exist_ok=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,22 +18,6 @@ class Export(DB.Model):
     geometry_srid = DB.Column(DB.Integer)
     public = DB.Column(DB.Boolean, nullable=False, default=False)
 
-    def __init__(self,
-                 label,
-                 schema_name,
-                 view_name,
-                 desc=None,
-                 geometry_field=None,
-                 geometry_srid=current_app.config['LOCAL_SRID'],
-                 public=False):
-        self.label = label
-        self.schema_name = schema_name
-        self.view_name = view_name
-        self.desc = desc
-        self.geometry_field = geometry_field
-        self.geometry_srid = geometry_srid
-        self.public = public
-
     def __str__(self):
         return "<Export(id='{}', label='{}')>".format(self.id, self.label)
 

--- a/config/swagger-ui_api.template.yml
+++ b/config/swagger-ui_api.template.yml
@@ -170,12 +170,12 @@ paths:
           description: Unexpected usage
         '403':
           description: Unauthenticated
-  /{{API_URL}}/{id}/{format}:
+  /{{API_URL}}/1/{format}:
     get:
       security:
         # - tokenAuth: []
         - bearerAuth: []
-      summary: Returns the format-specified data from the export the user has access to.
+      summary: Returns the SINP export.
       description: |
         More specific data may be obtained through the following query filters.
         In its simplest form:
@@ -512,3 +512,9 @@ paths:
           description: Unexpected usage
         '403':
           description: Unauthenticated | Insufficient rights
+  /{{API_URL}}/{id}/{format}:
+    get:
+      security:
+        # - tokenAuth: []
+        - bearerAuth: []
+      summary: Returns the format-specified data from the export the user has access to.

--- a/frontend/app/export-list/export-list.component.html
+++ b/frontend/app/export-list/export-list.component.html
@@ -1,93 +1,98 @@
 <div id="all" class="container-fluid">
-  <form [formGroup]="modalForm" class="modal-content">
     <div class="row row-m">
       <div class="container card">
-        <div id="title">
-          <h2>EXPORTS</h2>
-          <hr align="left" width="75%">
+        <div class="card-body">
+          <div id="title">
+            <h2>EXPORTS</h2>
+            <hr >
+          </div>
+          <div id="textPresentation">
+            <p>Voici la liste des exports disponibles. Ces exports ont été programmés par l'administrateur de GeoNature.</p>
+          </div>
+          <div id="textPresentation">
+            <p>Pour modifier cette liste ou disposer d'exports supplémentaires, veuillez contacter le service administrateur.</p>
+          </div>
+          <!-- Liste des exports disponibles au téléchargement -->
+          <div>
+            <ngx-datatable
+              [loadingIndicator]="loadingIndicator"
+              [rows]="exports$ | async"
+              [columnMode]="'flex'"
+              [rowHeight]="'auto'"
+              [limit]="6"
+              [reorderable]="true">
+                <ngx-datatable-column name="Nom export" prop="label" [flexGrow]="1">
+                  <ng-template let-value="value" ngx-datatable-cell-template>
+                    {{value}}
+                  </ng-template>
+                </ngx-datatable-column>
+                <ngx-datatable-column name="Description" prop="desc" [flexGrow]="2">
+                  <ng-template let-value="value" ngx-datatable-cell-template>
+                    {{value}}
+                  </ng-template>
+                </ngx-datatable-column>
+                <ngx-datatable-column name="Actions" prop="id" [flexGrow]="3">
+                  <ng-template let-value="value" ngx-datatable-cell-template>
+                    <button id="{{value}}" type="submit"
+                            class="btn btn-outline-primary"
+                            [disabled]="!buttonDisabled"
+                            (click)="selectFormat(value)">Télécharger</button>
+                  </ng-template>
+                </ngx-datatable-column>
+            </ngx-datatable>
         </div>
-        <div id="textPresentation">
-          <p>Voici la liste des exports disponibles. Ces exports ont été programmés par l'administrateur de GeoNature.</p>
         </div>
-        <div id="textPresentation">
-          <p>Pour modifier cette liste ou disposer d'exports supplémentaires, veuillez contacter le service administrateur.</p>
-        </div>
-        <!-- Liste des exports disponibles au téléchargement -->
-        <div>
-          <ngx-datatable
-            [loadingIndicator]="loadingIndicator"
-            [rows]="exports$ | async"
-            [columnMode]="'flex'"
-            [rowHeight]="'auto'"
-            [limit]="6"
-            [reorderable]="true">
-              <ngx-datatable-column name="Nom export" prop="label" [flexGrow]="1">
-                <ng-template let-value="value" ngx-datatable-cell-template>
-                  {{value}}
-                </ng-template>
-              </ngx-datatable-column>
-              <ngx-datatable-column name="Description" prop="desc" [flexGrow]="2">
-                <ng-template let-value="value" ngx-datatable-cell-template>
-                  {{value}}
-                </ng-template>
-              </ngx-datatable-column>
-              <ngx-datatable-column name="Actions" prop="id" [flexGrow]="3">
-                <ng-template let-value="value" ngx-datatable-cell-template>
-                  <button id="api_id_{{value}}"
-                          class="btn btn-outline-warning"
-                          (click)=openAPIDocumentation()>API</button>
-                  <button id="{{value}}" type="submit"
-                          class="btn btn-outline-primary"
-                          [disabled]="!buttonDisabled"
-                          (click)="selectFormat(value)">Télécharger</button>
-                </ng-template>
-              </ngx-datatable-column>
-          </ngx-datatable>
-        </div>
-        <div id="checkLicence">
-          <label for="licence">Accepter la licence</label>
-          <input type="checkbox" class="form-control" id="licence" (click)="follow()" required/>
-        </div>
-
-        <div id="readlicence">
-          <a href="external_assets/exports/licence.pdf" download="licence.pdf" type="application/octet-stream">
-            <input type="button" class="btn btn-outline-secondary btn-sm pull-right" value="Lire la licence">
-          </a>
-        </div>
+        <div class="card-footer">
+            <div class="d-flex justify-content-between">
+                <button id="api_id_{{value}}" class="btn btn-warning" (click)=openAPIDocumentation()>Explorer l'API
+                </button>
+              <div class="wrapper-licence">
+                  <div class="form-check" id="checkLicence">
+                    <input type="checkbox" class="form-check-input" id="licence" (click)="follow()" required/>
+                    <label class="form-check-label" for="licence">Accepter la licence</label>
+                  </div>
+                  <div id="readlicence">
+                    <a href="external_assets/exports/licence.pdf" alt="Télécharger la licence en pdf"  title="Télécharger la licence en pdf" download="licence.pdf" type="application/octet-stream">
+                      <input type="button" class="btn btn-link btn-sm" value="Lire la licence">
+                    </a>
+                  </div>
+              </div>
+            </div>
+          </div>
       </div>
     </div>
     <!-- Modal Téléchargement Popup-->
     <ng-template #content let-c="close" let-d="dismiss">
-
-      <!-- Modal content-->
-      <div class="modal-header">
-          <h4 class="modal-title">Configuration de l'export</h4>
-      </div>
-
-      <div class="modal-body">
-        <!-- Formulaire pour le choix des standards et des formats de téléchargement des fichiers -->
-        <br>
-        <ul> <li> Choisir un format </li> </ul>
-        <select class="form-control" id="formatSelection"
-                formControlName="formatSelection" required autocomplete="off"
-                (change)="downloading=false">
-                <option value="csv">CSV</option>
-                <option value="json">JSON</option>
-                <option value="shp" [disabled]="!_export.geometry_field">SHP</option>
-                <!-- <option value="rdf" [disabled]="true">RDF</option> -->
-        </select>
-        <!-- Affichage d'une barre de progression lors du téléchargement du fichier -->
-        <div *ngIf="downloading">
-          <download-progress-bar></download-progress-bar>
+      <form [formGroup]="modalForm" class="modal-content">
+        <!-- Modal content-->
+        <div class="modal-header">
+            <h4 class="modal-title">Configuration de l'export</h4>
         </div>
-        <br>
-      </div>
 
-      <!-- Bouton de fermeture de la modal pop-up ou lancement du téléchargement -->
-      <div class="modal-footer" id="choicePopup">
-        <button type="submit" class="btn btn-danger" data-dismiss="modal" (click)="c('Close click')">Fermer</button>
-        <button [disabled]="!modalForm.valid" id="widthButton" type="submit" class="btn btn-success" (click)="download()">OK</button>
-      </div>
+        <div class="modal-body">
+          <!-- Formulaire pour le choix des standards et des formats de téléchargement des fichiers -->
+          <br>
+          <ul> <li> Choisir un format </li> </ul>
+          <select class="form-control" id="formatSelection"
+                  formControlName="formatSelection" required autocomplete="off"
+                  (change)="downloading=false">
+                  <option value="csv">CSV</option>
+                  <option value="json">JSON</option>
+                  <option value="shp" [disabled]="!_export.geometry_field">SHP</option>
+                  <!-- <option value="rdf" [disabled]="true">RDF</option> -->
+          </select>
+          <!-- Affichage d'une barre de progression lors du téléchargement du fichier -->
+          <div *ngIf="downloading">
+            <download-progress-bar></download-progress-bar>
+          </div>
+          <br>
+        </div>
+
+        <!-- Bouton de fermeture de la modal pop-up ou lancement du téléchargement -->
+        <div class="modal-footer" id="choicePopup">
+          <button type="submit" class="btn btn-danger" data-dismiss="modal" (click)="c('Close click')">Fermer</button>
+          <button [disabled]="!modalForm.valid" id="widthButton" type="submit" class="btn btn-success" (click)="download()">OK</button>
+        </div>
+      </form>
     </ng-template>
-  </form>
 </div>

--- a/frontend/app/export-list/export-list.component.scss
+++ b/frontend/app/export-list/export-list.component.scss
@@ -130,15 +130,11 @@ button:disabled, .btn.disabled, .btn:disabled, .disabled {
 
 }
 
-#checkLicence{
-  margin-left:50px;
-  margin-top: 25px;
-  margin-bottom: 5px;
-  align-self: center;
-}
-
 #readlicence{
   margin-bottom: 10px;
+  .btn.btn-link {
+    padding-left: 0;
+  }
 }
 
 #myModal{

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,5 +2,5 @@ package_format_version = '1'
 module_code = 'EXPORTS'
 module_version = '1.0.0'
 min_geonature_version = '2.0.0'
-max_geonature_version = '2.0.0'
-exclude_geonature_versions = [ '2.0.1', '2.0.3' ]
+max_geonature_version = '2.0.1'
+exclude_geonature_versions = [ '2.0.2', '2.0.3' ]


### PR DESCRIPTION
Aministration des exports et permissions associés avec flask-admin.

L'app admin utilisée est celle de pypnnomenclature... donc la gestion des export se trouve dans l'administration des nomenclatures.

Y-a t-il un moyen d'utiliser l'instance flask-admin de géonature qui se trouve dans server.py ?