### PR TITLE
Compat 2.7

### DIFF
--- a/backend/blueprint.py
+++ b/backend/blueprint.py
@@ -441,7 +441,8 @@ def getExports(info_role):
         LOGGER.critical("%s", str(e))
         return {"api_error": "logged_error"}, 400
     else:
-        return [export.as_dict(recursif=True) for export in exports]
+
+        return [export.as_dict(fields=["licence"]) for export in exports]
 
 
 @blueprint.route("/api/<int:id_export>", methods=["GET"])


### PR DESCRIPTION
Avec l'ajout du support de la sérialisation des backref, la route `/export` ne fonctionne plus si on on a des `ExportSchedules`.
Il faut le retirer de la sérialisation, ça permet aussi de virer le recursif=True qui est déprécié