### PR TITLE
Prepare 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Module permettant d'ajouter des fonctionnalités d'export à l'application GeoNa
 
 ### Email
 
-Le module d'export envoie des emails indiquant que l'export demandé est prêt. Pour cela il est nécessaire de configurer au préalable les paramètres d'envoi d'emails dans la configuration générale de GeoNature (section ``[MAIL_CONFIG]`` de ``geonature/config/geonature_config.toml``).
+Le module d'export envoie des emails indiquant que l'export demandé est prêt. Pour cela il est nécessaire d'avoir configuré au préalable les paramètres d'envoi d'emails dans la configuration générale de GeoNature (section ``[MAIL_CONFIG]`` de ``geonature/config/geonature_config.toml``).
 
 La configuration des emails utilise les paramètres définis par Flask_mail. Pour avoir accès à l'ensemble des paramètres se référer à la [documentation complète](https://flask-mail.readthedocs.io/en/latest/).
 
@@ -31,7 +31,7 @@ La configuration des emails utilise les paramètres définis par Flask_mail. Pou
 
 ### Autres paramètres
 
-Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier ``gn_module_export/config/conf_gn_module.toml`` du module Export :
+Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier ``gn_module_export/config/conf_gn_module.toml`` du module Export (ou dans ``geonature/config/exports_config.toml``, recommandé depuis GeoNature 2.12.0) :
 
 * ``export_schedules_dir`` : chemin absolu du dossier où les exports programmés seront déposés lors de la réalisation de la commande ``gn_exports_run_cron_export``
 * ``export_dsw_dir`` : chemin absolu du dossier où l'export sémantique au format Darwin-SW sera réalisé
@@ -41,13 +41,10 @@ Les paramètres du module surcouchables concernent les dossiers d'export et se c
 
 Voir le fichier ``gn_module_export/config/conf_gn_module.toml.example`` d'exemple des paramètres.
 
-Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier ``gn_module_export/config/conf_gn_module.toml``, vous devez lancer une commande pour appliquer les modifications des paramètres :
+Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier ``gn_module_export/config/conf_gn_module.toml`` (ou dans ``geonature/config/exports_config.toml``), vous devez recharger GeoNature pour appliquer les modifications des paramètres :
 
 ```
-source ~/geonature/backend/venv/bin/activate
-geonature update-configuration
 sudo systemctl reload geonature
-deactivate
 ```
 
 ## Commande d'installation
@@ -94,7 +91,7 @@ mv /home/`whoami`/gn_module_export /home/`whoami`/gn_module_export_old
 mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
 ```
 
-- Rapatriez le fichier de configuration
+- Rapatriez le fichier de configuration (pas nécessaire si vous avez configuré le module dans ``geonature/config/exports_config.toml``)
 
 ```
 cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami`/gn_module_export/config/conf_gn_module.toml
@@ -158,7 +155,7 @@ Il est possible de surcharger la documentation Swagger de chaque API en respecta
 Pour réaliser les exports planifiés une commande est disponible `geonature exports gn_exports_run_cron_export`.
 
 Cette commande liste des exports planifiés dans la table ``gn_exports.t_export_schedules`` et les exécute si besoin. La fonction considère qu'un export doit être réalisé à partir du moment où le fichier généré précedemment est plus ancien (en jours) que la fréquence définie (dans ``gn_exports.t_export_schedules.frequency``).
-Par défaut, le fichier généré par un export planifié est disponible à l'adresse : ``<URL_GEONATURE>/api/static/exports/schedules/Nom_Export.Format``.
+Par défaut, le fichier généré par un export planifié est disponible à l'adresse : ``<URL_GEONATURE>/api/media/exports/schedules/Nom_Export.Format``.
 
 Pour lancer les exports il faut utiliser les instructions suivantes :
 
@@ -185,8 +182,8 @@ sudo nano /etc/apache2/sites-available/geonature.conf
 Ajoutez ces lignes au milieu de la configuration Apache de GeoNature (en adaptant le chemin absolu et le nom de l'alias comme vous le souhaitez). Exemple pour les exports planifiés :
 
 ```
-Alias "/exportschedules" "/home/myuser/geonature/backend/static/exports/schedules"
-<Directory "/home/myuser/geonature/backend/static/exports/schedules">
+Alias "/exportschedules" "/home/myuser/geonature/backend/media/exports/schedules"
+<Directory "/home/myuser/geonature/backend/media/exports/schedules">
    AllowOverride None
    Require all granted
 </Directory>
@@ -195,14 +192,14 @@ Alias "/exportschedules" "/home/myuser/geonature/backend/static/exports/schedule
 Pour les fichiers générés à la demande par les utilisateurs :
 
 ```
-Alias "/exportfiles" "/home/myuser/geonature/backend/static/exports/usr_generated"
-<Directory "/home/myuser/geonature/backend/static/exports/usr_generated">
+Alias "/exportfiles" "/home/myuser/geonature/backend/media/exports/usr_generated"
+<Directory "/home/myuser/geonature/backend/media/exports/usr_generated">
    AllowOverride None
    Require all granted
 </Directory>
 ```
 
-Renseignez le paramètre ``export_web_url`` en cohérence dans le fichier ``config/conf_gn_module.toml`` du module (``export_web_url=<URL_GEONATURE>/exportfiles`` dans cet exemple).
+Renseignez le paramètre ``export_web_url`` en cohérence dans le fichier ``config/conf_gn_module.toml`` du module (``export_web_url=<URL_GEONATURE>/exportfiles`` dans cet exemple) ou dans ``geonature/config/exports_config.toml`` (depuis GeoNature 2.12.0).
 
 Rechargez la configuration Apache pour prendre en compte les modifications :
 
@@ -212,7 +209,7 @@ sudo /etc/init.d/apache2 reload
 
 Dans cet exemple les fichiers des exports planifiés seront accessibles à l'adresse ``<URL_GEONATURE>/exportschedules/Nom_Export.Format``. Le chemin ``/exportschedules/`` est adaptable bien entendu au niveau de l'alias de la configuration Apache. Les fichiers des exports générés à la demande par les utilisateurs seront disponibles à l'adresse ``<URL_GEONATURE>/exportfiles/Date_Nom_Export.Format``
 
-Une autre solution plus globale serait de compléter la configuration Apache de GeoNature pour que l'ensemble de son répertoire ``backend/static`` soit servi en mode fichier par Apache. Voir http://docs.geonature.fr/conf-apache.html.
+Une autre solution plus globale serait de compléter la configuration Apache de GeoNature pour que l'ensemble de son répertoire ``backend/media`` soit servi en mode fichier par Apache. Voir http://docs.geonature.fr/conf-apache.html.
 
 # Export RDF au format sémantique Darwin-SW
 
@@ -232,7 +229,7 @@ API :
     Paramètres :
         - limit
         - offset
-        - champs présents dans la vue v_exports_synthese_sinp_rdf
+        - champs présents dans la vue ``v_exports_synthese_sinp_rdf``
 
 Fichier .ttl, généré par la commande :
 
@@ -242,7 +239,7 @@ source backend/venv/bin/activate
 geonature exports gn_exports_run_cron_export_dsw --limit 10 --offset=0
 ```
 
-Le fichier est alors disponible à l'adresse <URL_GEONATURE>/api/static/exports/dsw/export_dsw.ttl.
+Le fichier est alors disponible à l'adresse <URL_GEONATURE>/api/media/exports/dsw/export_dsw.ttl.
 
 Les paramètres ``limit`` et ``offset`` sont optionnels. S'ils ne sont pas spécifiés l'export se fera sur l'ensemble des données.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Le module d'export envoie des emails indiquant que l'export demandé est prêt. 
 
 La configuration des emails utilise les paramètres définis par Flask_mail. Pour avoir accès à l'ensemble des paramètres se référer à la [documentation complète](https://flask-mail.readthedocs.io/en/latest/).
 
-```
+```toml
 [MAIL_CONFIG]
     MAIL_SERVER = "monserver.mail"
     MAIL_PORT = 465 # Si différent de 465 en SSL
@@ -31,7 +31,7 @@ La configuration des emails utilise les paramètres définis par Flask_mail. Pou
 
 ### Autres paramètres
 
-Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier `geonature/config/exports_config.toml` :
+Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier `exports_config.toml` dans le dossier de configuration de GeoNature (`geonature/config/`) :
 
 * ``export_schedules_dir`` : chemin absolu du dossier où les exports programmés seront déposés lors de la réalisation de la commande ``gn_exports_run_cron_export``
 * ``export_dsw_dir`` : chemin absolu du dossier où l'export sémantique au format Darwin-SW sera réalisé
@@ -39,11 +39,17 @@ Les paramètres du module surcouchables concernent les dossiers d'export et se c
 * ``export_web_url`` : URL des fichiers exportés à la demande par les utilisateurs
 * ``expose_dsw_api`` : Indique si la route d'appel à l'API du Darwin SW est active ou non. Par défaut la route n'est pas activée.
 
-Voir le fichier ``gn_module_export/config/conf_gn_module.toml.example`` d'exemple des paramètres.
+Voir le fichier ``exports_config.toml.example`` d'exemple des paramètres.
+
+Pour créer le fichier de configuration du module, à partir du fichier d'exemple : 
+
+```bash
+cp ~/gn_module_export/exports_config.toml.example ~/geonature/config/exports_config.toml
+```
 
 Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier `geonature/config/exports_config.toml`, vous devez recharger GeoNature pour appliquer les modifications des paramètres :
 
-```
+```bash
 sudo systemctl reload geonature
 ```
 
@@ -51,7 +57,7 @@ sudo systemctl reload geonature
 
 - Téléchargez le module dans ``/home/<myuser>/``, en remplacant ``X.Y.Z`` par la version souhaitée
 
-```
+```bash
 wget https://github.com/PnX-SI/gn_module_export/archive/X.Y.Z.zip
 unzip X.Y.Z.zip
 rm X.Y.Z.zip
@@ -59,13 +65,13 @@ rm X.Y.Z.zip
 
 - Renommez le répertoire du module
 
-```
+```bash
 mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
 ```
 
 - Lancez l'installation du module
 
-```
+```bash
 source ~/geonature/backend/venv/bin/activate
 geonature install-gn-module ~/gn_module_export EXPORTS
 sudo systemctl restart geonature
@@ -78,7 +84,7 @@ deactivate
 
 - Téléchargez la nouvelle version du module
 
-```
+```bash
 wget https://github.com/PnX-SI/gn_module_export/archive/X.Y.Z.zip
 unzip X.Y.Z.zip
 rm X.Y.Z.zip
@@ -86,7 +92,7 @@ rm X.Y.Z.zip
 
 - Renommez l'ancien et le nouveau répertoire
 
-```
+```bash
 mv /home/`whoami`/gn_module_export /home/`whoami`/gn_module_export_old
 mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
 ```
@@ -94,7 +100,7 @@ mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
 - Si vous avez encore votre configuration du module dans les dossiers du module, rapatriez le fichier de configuration dans le dossier
   de configuration centralisée de GeoNature (depuis sa version 2.11) :
 
-```
+```bash
 cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami`/geonature/config/exports_conf.toml
 ```
 
@@ -102,7 +108,7 @@ cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami
 
 - Lancez la mise à jour du module
 
-```
+```bash
 source ~/geonature/backend/venv/bin/activate
 geonature install-gn-module ~/gn_module_export EXPORTS
 sudo systemctl restart geonature
@@ -160,7 +166,7 @@ Par défaut, le fichier généré par un export planifié est disponible à l'ad
 
 Pour lancer les exports il faut utiliser les instructions suivantes :
 
-```
+```bash
 cd GN2_HOME
 source backend/venv/bin/activate
 geonature exports gn_exports_run_cron_export
@@ -176,7 +182,7 @@ Par défaut les fichiers sont servis par le serveur web Gunicorn qui a un timeou
 
 Pour cela, modifier la configuration Apache de GeoNature et ajouter un alias vers le dossier où sont générés les fichiers exportés :
 
-```
+```bash
 sudo nano /etc/apache2/sites-available/geonature.conf
 ```
 
@@ -204,7 +210,7 @@ Renseignez le paramètre ``export_web_url`` en cohérence dans le fichier ``geon
 
 Rechargez la configuration Apache pour prendre en compte les modifications :
 
-```
+```bash
 sudo /etc/init.d/apache2 reload
 ```
 
@@ -234,7 +240,7 @@ API :
 
 Fichier .ttl, généré par la commande :
 
-```
+```bash
 cd GN2_HOME
 source backend/venv/bin/activate
 geonature exports gn_exports_run_cron_export_dsw --limit 10 --offset=0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ La configuration des emails utilise les paramètres définis par Flask_mail. Pou
 
 ### Autres paramètres
 
-Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier ``gn_module_export/config/conf_gn_module.toml`` du module Export (ou dans ``geonature/config/exports_config.toml``, recommandé depuis GeoNature 2.12.0) :
+Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier `geonature/config/exports_config.toml` :
 
 * ``export_schedules_dir`` : chemin absolu du dossier où les exports programmés seront déposés lors de la réalisation de la commande ``gn_exports_run_cron_export``
 * ``export_dsw_dir`` : chemin absolu du dossier où l'export sémantique au format Darwin-SW sera réalisé
@@ -41,7 +41,7 @@ Les paramètres du module surcouchables concernent les dossiers d'export et se c
 
 Voir le fichier ``gn_module_export/config/conf_gn_module.toml.example`` d'exemple des paramètres.
 
-Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier ``gn_module_export/config/conf_gn_module.toml`` (ou dans ``geonature/config/exports_config.toml``), vous devez recharger GeoNature pour appliquer les modifications des paramètres :
+Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier `geonature/config/exports_config.toml`, vous devez recharger GeoNature pour appliquer les modifications des paramètres :
 
 ```
 sudo systemctl reload geonature
@@ -91,10 +91,11 @@ mv /home/`whoami`/gn_module_export /home/`whoami`/gn_module_export_old
 mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
 ```
 
-- Rapatriez le fichier de configuration (pas nécessaire si vous avez configuré le module dans ``geonature/config/exports_config.toml``)
+- Si vous avez encore votre configuration du module dans les dossiers du module, rapatriez le fichier de configuration dans le dossier
+  de configuration centralisée de GeoNature (depuis sa version 2.11) :
 
 ```
-cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami`/gn_module_export/config/conf_gn_module.toml
+cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami`/geonature/config/exports_conf.toml
 ```
 
 - Rapatriez aussi vos éventuelles surcouches des documentations Swagger des exports depuis le dossier ``/home/`whoami`/gn_module_export_old/backend/templates/swagger/``.
@@ -199,7 +200,7 @@ Alias "/exportfiles" "/home/myuser/geonature/backend/media/exports/usr_generated
 </Directory>
 ```
 
-Renseignez le paramètre ``export_web_url`` en cohérence dans le fichier ``config/conf_gn_module.toml`` du module (``export_web_url=<URL_GEONATURE>/exportfiles`` dans cet exemple) ou dans ``geonature/config/exports_config.toml`` (depuis GeoNature 2.12.0).
+Renseignez le paramètre ``export_web_url`` en cohérence dans le fichier ``geonature/config/exports_config.toml`` (``export_web_url=<URL_GEONATURE>/exportfiles`` dans cet exemple).
 
 Rechargez la configuration Apache pour prendre en compte les modifications :
 
@@ -209,7 +210,7 @@ sudo /etc/init.d/apache2 reload
 
 Dans cet exemple les fichiers des exports planifiés seront accessibles à l'adresse ``<URL_GEONATURE>/exportschedules/Nom_Export.Format``. Le chemin ``/exportschedules/`` est adaptable bien entendu au niveau de l'alias de la configuration Apache. Les fichiers des exports générés à la demande par les utilisateurs seront disponibles à l'adresse ``<URL_GEONATURE>/exportfiles/Date_Nom_Export.Format``
 
-Une autre solution plus globale serait de compléter la configuration Apache de GeoNature pour que l'ensemble de son répertoire ``backend/media`` soit servi en mode fichier par Apache. Voir http://docs.geonature.fr/conf-apache.html.
+Une autre solution plus globale serait de compléter la configuration Apache de GeoNature pour que l'ensemble de son répertoire ``backend/media`` soit servi en mode fichier par Apache.
 
 # Export RDF au format sémantique Darwin-SW
 
@@ -261,7 +262,7 @@ Bibliographie :
 
 # Autres
 
-* CCTP de définition du projet : http://geonature.fr/documents/cctp/2017-10-CCTP-GeoNature-interoperabilite.pdf
+* CCTP de définition du projet : https://geonature.fr/documents/cctp/2017-10-CCTP-GeoNature-interoperabilite.pdf
 * Biodiversité et opendata (Présentation d'Olivier Rovellotti au Forum TIC 2018) : https://geonature.fr/documents/2018-06-forum-tic-biodiversite-opendata-rovellotti.pdf
 * Biodiversité et linked data (Présentation d'Amandine Sahl au Forum TIC 2018) : https://geonature.fr/documents/2018-06-forum-tic-biodiversite-linkeddata-sahl.pdf
 * OPENDATA ET BIODIVERSITÉ (Pourquoi et comment publier ses données de biodiversité en opendata ?) : https://geonature.fr/documents/2019-04-biodiversite-opendata.pdf

--- a/README.md
+++ b/README.md
@@ -31,27 +31,21 @@ La configuration des emails utilise les paramètres définis par Flask_mail. Pou
 
 ### Autres paramètres
 
-Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier `exports_config.toml` dans le dossier de configuration de GeoNature (`geonature/config/`) :
+Les paramètres du module surcouchables concernent les dossiers d'export et se configurent dans le fichier `exports_config.toml`,
+à créer dans le dossier de configuration de GeoNature (`geonature/config/`) :
 
-* ``export_schedules_dir`` : chemin absolu du dossier où les exports programmés seront déposés lors de la réalisation de la commande ``gn_exports_run_cron_export``
+* ``export_schedules_dir`` : chemin absolu du dossier où les exports programmés seront déposés
 * ``export_dsw_dir`` : chemin absolu du dossier où l'export sémantique au format Darwin-SW sera réalisé
 * ``export_dsw_filename`` : nom du fichier de l'export sémantique au format turtle (``.ttl``)
 * ``export_web_url`` : URL des fichiers exportés à la demande par les utilisateurs
 * ``expose_dsw_api`` : Indique si la route d'appel à l'API du Darwin SW est active ou non. Par défaut la route n'est pas activée.
 
-Voir le fichier ``exports_config.toml.example`` d'exemple des paramètres.
+Vous pouvez donc modifier la configuration du module en créant un fichier 
+`exports_config.toml` dans le dossier `config` de GeoNature, en vous inspirant 
+du fichier `exports_config.toml.example` et en surcouchant les paramètres que vous souhaitez
 
-Pour créer le fichier de configuration du module, à partir du fichier d'exemple : 
-
-```bash
-cp ~/gn_module_export/exports_config.toml.example ~/geonature/config/exports_config.toml
-```
-
-Si vous modifiez les valeurs par défaut de ces paramètres en les renseignant dans le fichier `geonature/config/exports_config.toml`, vous devez recharger GeoNature pour appliquer les modifications des paramètres :
-
-```bash
-sudo systemctl reload geonature
-```
+Pour appliquer les modifications de la configuration du module, consultez 
+la [rubrique dédiée de la documentation de GeoNature](https://docs.geonature.fr/installation.html#module-config).
 
 ## Commande d'installation
 
@@ -66,7 +60,7 @@ rm X.Y.Z.zip
 - Renommez le répertoire du module
 
 ```bash
-mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
+mv ~/gn_module_export-X.Y.Z ~/gn_module_export
 ```
 
 - Lancez l'installation du module
@@ -93,18 +87,18 @@ rm X.Y.Z.zip
 - Renommez l'ancien et le nouveau répertoire
 
 ```bash
-mv /home/`whoami`/gn_module_export /home/`whoami`/gn_module_export_old
-mv /home/`whoami`/gn_module_export-X.Y.Z /home/`whoami`/gn_module_export
+mv ~/gn_module_export ~/gn_module_export_old
+mv ~/gn_module_export-X.Y.Z ~/gn_module_export
 ```
 
-- Si vous avez encore votre configuration du module dans les dossiers du module, rapatriez le fichier de configuration dans le dossier
-  de configuration centralisée de GeoNature (depuis sa version 2.11) :
+- Si vous avez encore votre configuration du module dans le dossier `config` du module, 
+  copiez le vers le dossier de configuration centralisée de GeoNature :
 
 ```bash
-cp /home/`whoami`/gn_module_export_old/config/conf_gn_module.toml  /home/`whoami`/geonature/config/exports_conf.toml
+cp ~/gn_module_export_old/config/conf_gn_module.toml  ~/geonature/config/exports_conf.toml
 ```
 
-- Rapatriez aussi vos éventuelles surcouches des documentations Swagger des exports depuis le dossier ``/home/`whoami`/gn_module_export_old/backend/templates/swagger/``.
+- Rapatriez aussi vos éventuelles surcouches des documentations Swagger des exports depuis le dossier `~/gn_module_export_old/backend/templates/swagger/`.
 
 - Lancez la mise à jour du module
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Module permettant d'ajouter des fonctionnalités d'export à l'application GeoNa
 
 Le module d'export envoie des emails indiquant que l'export demandé est prêt. Pour cela il est nécessaire d'avoir configuré au préalable les paramètres d'envoi d'emails dans la configuration générale de GeoNature (section ``[MAIL_CONFIG]`` de ``geonature/config/geonature_config.toml``).
 
-La configuration des emails utilise les paramètres définis par Flask_mail. Pour avoir accès à l'ensemble des paramètres se référer à la [documentation complète](https://flask-mail.readthedocs.io/en/latest/).
+La configuration des emails utilise les paramètres définis par Flask-Mail. Pour avoir accès à l'ensemble des paramètres se référer à la [documentation complète](https://flask-mail.readthedocs.io/en/latest/).
 
 ```toml
 [MAIL_CONFIG]
@@ -42,7 +42,7 @@ Les paramètres du module surcouchables concernent les dossiers d'export et se c
 
 Vous pouvez donc modifier la configuration du module en créant un fichier 
 `exports_config.toml` dans le dossier `config` de GeoNature, en vous inspirant 
-du fichier `exports_config.toml.example` et en surcouchant les paramètres que vous souhaitez
+du fichier `exports_config.toml.example` et en surcouchant les paramètres que vous souhaitez.
 
 Pour appliquer les modifications de la configuration du module, consultez 
 la [rubrique dédiée de la documentation de GeoNature](https://docs.geonature.fr/installation.html#module-config).
@@ -149,25 +149,23 @@ Par défaut une documentation Swagger est générée automatiquement pour chaque
 Il est possible de surcharger la documentation Swagger de chaque API en respectant certaines conventions :
 
 1. Créer un fichier au format OpenAPI décrivant votre export
-2. Sauvegarder le fichier ``geonature/external_modules/exports/backend/templates/swagger/api_specification_{id_export}.json``
+2. Sauvegarder le fichier ``~/gn_module_export/backend/templates/swagger/api_specification_{id_export}.json``
+
+# Générer un export
+
+Pour générer le ficheir d’un export, une commande est disponible : `geonature exports generate <ID_EXPORT>`
+Pour plus d’information sur l’utilisation de cette commande, lancer `geonature exports generate --help`.
 
 # Export planifié
 
-Pour réaliser les exports planifiés une commande est disponible `geonature exports gn_exports_run_cron_export`.
+Il est possible d’automatiser la génération des fichiers des exports.
+Ceci est configurable depuis la section « Planification des exports » dans le module Admin.
 
-Cette commande liste des exports planifiés dans la table ``gn_exports.t_export_schedules`` et les exécute si besoin. La fonction considère qu'un export doit être réalisé à partir du moment où le fichier généré précedemment est plus ancien (en jours) que la fréquence définie (dans ``gn_exports.t_export_schedules.frequency``).
+Les exports sont générés la nuit à 3 heures, selon la fréquence de génération configurée (en jours).
+
+Vous pouvez forcer la génération d’un export manuellement avec la commande de génération `geonature exports generate`.
+
 Par défaut, le fichier généré par un export planifié est disponible à l'adresse : ``<URL_GEONATURE>/api/media/exports/schedules/Nom_Export.Format``.
-
-Pour lancer les exports il faut utiliser les instructions suivantes :
-
-```bash
-cd GN2_HOME
-source backend/venv/bin/activate
-geonature exports gn_exports_run_cron_export
-```
-
-Vous pouvez automatiser les exports en configurant une tache cron.
-Pour aller voir le CRON  : ``crontab -e``
 
 
 # URL des fichiers
@@ -237,7 +235,7 @@ Fichier .ttl, généré par la commande :
 ```bash
 cd GN2_HOME
 source backend/venv/bin/activate
-geonature exports gn_exports_run_cron_export_dsw --limit 10 --offset=0
+geonature exports generate-dsw --limit 10 --offset=0
 ```
 
 Le fichier est alors disponible à l'adresse <URL_GEONATURE>/api/media/exports/dsw/export_dsw.ttl.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 * Centralisation de la configuration du module dans le dossier de configuration de GeoNature
 * Répercussion de la réorganisation des dossiers dans GeoNature. Les exports sont désormais stockés dans ``geonature/backend/media/exports``
 * Répercussion de la refactorisation des permissions réalisée dans GeoNature 2.12.0
+* Le cron lançant automatiquement la tache de génération des exports planifiés a été remplacée par un tache Celery Beat, installée automatiquement avec le module (#125)
+* La fonction `gn_exports_run_cron_export()` est remplacée par `generate(export_id, export_format, scheduled, skip_newer_than)` (#125)
+* La fonction `gn_exports_run_cron_export_dsw()` est remplacée par `generate_dsw()` (#125)
+* Le script `gn_export_cron.sh` a été supprimé (#125)
 * Compatibilité avec SQLAlchemy 1.4 et Flask-SQLAlchemy 1.4
 
 **🐛 Corrections**
@@ -24,7 +28,8 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 
 **⚠️ Notes de version**
 
-Le dossier de stockage des exports a été modifié de ``geonature/backend/static/exports/`` à ``geonature/backend/media/exports/``. Répercutez éventuellement ce changement si vous aviez modifié la configuration du module ainsi que la configuration Apache de GeoNature (pour servir les fichiers exportés avec Apache - https://github.com/PnX-SI/gn_module_export/#url-des-fichiers).
+* Le dossier de stockage des exports a été modifié de ``geonature/backend/static/exports/`` à ``geonature/backend/media/exports/``. Répercutez éventuellement ce changement si vous aviez modifié la configuration du module ainsi que la configuration Apache de GeoNature (pour servir les fichiers exportés avec Apache - https://github.com/PnX-SI/gn_module_export/#url-des-fichiers).
+* Si vous aviez mis en place un cron système pour générer les exports planifiés (dans `/etc/cron/geonature` ou autre), vous pouvez le supprimer car ils sont désormais générés automatiquement avec Celery Beat.
 
 1.3.0 (2022-11-02)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,10 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 * Suppression de l'usage de ``MODULE_URL`` dans la configuration du module (https://github.com/PnX-SI/GeoNature/issues/2165) ???
 * Remove fileHandler logger. This handler wrongly use ``ROOT_DIR`` and is not docker-ready.
 
+**⚠️ Notes de version**
+
+Le dossier de stockage des exports a été modifié de ``geonature/backend/static/exports/`` à ``geonature/backend/media/exports/``. Répercutez éventuellement ce changement si vous aviez modifié la configuration Apache de GeoNature pour servir les fichiers exportés avec Apache (https://github.com/PnX-SI/gn_module_export/#url-des-fichiers)
+
 1.3.0 (2022-11-02)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 
 * Compatibilité avec Angular version 15, mis à jour dans la version 2.12.0 de GeoNature
 * Utilisation de la configuration dynamique (ne nécessitant plus de rebuilder le frontend à chaque modification de la configuration du module)
+* Centralisation de la configuration du module dans le dossier de configuration de GeoNature
 * Répercussion de la réorganisation des dossiers dans GeoNature. Les exports sont désormais stockés dans ``geonature/backend/media/exports``
 * Répercussion de la refactorisation des permissions réalisée dans GeoNature 2.12.0
 * Compatibilité avec SQLAlchemy 1.4 et Flask-SQLAlchemy 1.4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 
 * Compatibilité avec Angular version 15, mis à jour dans la version 2.12.0 de GeoNature
 * Utilisation de la configuration dynamique (ne nécessitant plus de rebuilder le frontend à chaque modification de la configuration du module)
+* Répercussion de la réorganisation des dossiers dans GeoNature. Les exports sont désormais stockés dans ``geonature/backend/media/exports``
 * Répercussion de la refactorisation des permissions réalisée dans GeoNature 2.12.0
 * Compatibilité avec SQLAlchemy 1.4 et Flask-SQLAlchemy 1.4
 
@@ -22,7 +23,7 @@ Nécessite la version 2.12.0 (ou plus) de GeoNature.
 
 **⚠️ Notes de version**
 
-Le dossier de stockage des exports a été modifié de ``geonature/backend/static/exports/`` à ``geonature/backend/media/exports/``. Répercutez éventuellement ce changement si vous aviez modifié la configuration Apache de GeoNature pour servir les fichiers exportés avec Apache (https://github.com/PnX-SI/gn_module_export/#url-des-fichiers)
+Le dossier de stockage des exports a été modifié de ``geonature/backend/static/exports/`` à ``geonature/backend/media/exports/``. Répercutez éventuellement ce changement si vous aviez modifié la configuration du module ainsi que la configuration Apache de GeoNature (pour servir les fichiers exportés avec Apache - https://github.com/PnX-SI/gn_module_export/#url-des-fichiers).
 
 1.3.0 (2022-11-02)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,17 @@
 CHANGELOG
 =========
 
-1.3.1 (unreleased)
+1.4.0 (unreleased)
 ------------------
+
+Nécessite la version 2.12.0 (ou plus) de GeoNature.
+
+**🚀 Nouveautés**
+
+* Compatibilité avec Angular version 15, mis à jour dans la version 2.12.0 de GeoNature
+* Utilisation de la configuration dynamique (ne nécessitant plus de rebuilder le frontend à chaque modification de la configuration du module)
+* Répercussion de la refactorisation des permissions réalisée dans GeoNature 2.12.0
+* Compatibilité avec SQLAlchemy 1.4 et Flask-SQLAlchemy 1.4
 
 **🐛 Corrections**
 


### PR DESCRIPTION
- [x] It also requires to update `base_export_dir` : https://github.com/PnX-SI/gn_module_export/blob/develop/backend/gn_module_export/conf_schema_toml.py#L16
- [x] And maybe several other changes, as exports are no more stored in ``geonature/backend/static/exports`` but in ``geonature/backend/media/exports`` : https://github.com/search?q=repo%3APnX-SI%2Fgn_module_export%20static&type=code ?