### PR TITLE
Api public export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Module permettant d'ajouter des fonctionnalités globales et transversales d'exp
 ## Configuration
 
 ### Paramètres
+
 * ``export_dsw_dir`` : chemin absolu ou relatif au dossier media du dossier où l'export sémantique au format Darwin-SW sera réalisé
 * ``export_dsw_filename`` : nom du fichier de l'export sémantique au format turtle (``.ttl``)
 * ``expose_dsw_api`` : Indique si la route d'appel à l'API du Darwin SW est active ou non. Par défaut la route n'est pas activée.
@@ -98,7 +99,7 @@ Pour créer un nouvel export, il faut au préalable créer une vue dans la base 
 
 Pour des questions de lisibilité, il est conseillé de créer la vue dans le schéma ``gn_exports``.
 
-Par défaut, un export public (accessible à tous les utilisateurs ayant accès au module Export d'une instance GeoNature) est créé basé sur la vue ``gn_exports.v_synthese_sinp``, contenant toutes les données présentes dans la Synthèse. Il est possible de limiter les données dans cet exeport (en ajoutant des critères dans la clause WHERE de la vue ``gn_exports.v_synthese_sinp``), de supprimer cet export ou de le limiter à certains utilisateurs uniquement.
+Par défaut, un export est créé, basé sur la vue ``gn_exports.v_synthese_sinp``, contenant toutes les données présentes dans la Synthèse. Il est possible de limiter les données dans cet exeport (en ajoutant des critères dans la clause WHERE de la vue ``gn_exports.v_synthese_sinp``), de supprimer cet export, de le rendre public ou de définir quels utilisateur y ont accès.
 
 Les fichiers exportés sont automatiquement supprimés 15 jours après avoir été générés (durée configurable avec le paramètre ``nb_days_keep_file``).
 
@@ -110,7 +111,7 @@ Dans la rubrique "Exports", sélectionner le menu ``Export`` puis cliquer sur ``
 
 ## Associer les roles ayant la permission d'accéder à cet export
 
-Si l'export est défini comme "Public" (``gn_exports.t_exports.public = True``), alors tous les utilisateurs ayant accès au module pourront accéder à cet export.  
+Si l'export est défini comme "Public" (``gn_exports.t_exports.public = True``), alors tous les utilisateurs ayant accès au module pourront accéder à cet export. Et son API sera accessible et ouverte publiquement, sans authentification.
 Sinon il est possible de définir les rôles (utilisateurs ou groupes) qui peuvent accéder à un export.
 
 Les permissions, définies à l'utilisateur ou à son groupe sur le module, permettent de donner accès aux exports de cette manière :

--- a/backend/gn_module_export/migrations/data/exports.sql
+++ b/backend/gn_module_export/migrations/data/exports.sql
@@ -332,7 +332,7 @@ COMMENT ON COLUMN gn_exports.v_synthese_sinp."methode_determination"  IS 'Descri
 
 -- Ajout d'un export par défaut basé sur la vue gn_exports.v_synthese_sinp
 INSERT INTO gn_exports.t_exports (label, schema_name, view_name, "desc", geometry_field, geometry_srid, public, id_licence)
-VALUES ('Synthese SINP', 'gn_exports', 'v_synthese_sinp', 'Export des données de la synthèse au standard SINP', 'geom', 4326, TRUE, 1);
+VALUES ('Synthese SINP', 'gn_exports', 'v_synthese_sinp', 'Export des données de la synthèse au standard SINP', 'geom', 4326, FALSE, 1);
 
 
 -- Vue des données de la synthèse au format DEE du SINP

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 * Suppression du champ permettant de renseigner un email lors de la demande de téléchargement d'un export (#170, par @amandine-sahl)
 * Révision, simplification et correction des permissions du module (#154, par @TheoLechemia, @ch-cna)
 * Simplification de l'association de rôles aux exports dans le module "Admin" en associant ceux-ci directement depuis le formulaire d'édition d'un export (#78, par @andriacap)
+* Les exports définis comme "Public" ont désormais leur API accessible de manière ouverte sans authentification
 * Suppression de la table `gn_exports.t_exports_logs` traçant les exports (#136, par @amandine-sahl)
 * Ajout du champ `gn_exports.t_exports.view_pk_column` permettant de spécifier la colonne d'unicité des vues d'exports (#149, par @amandine-sahl)
 * Mise en place d'une Github action pour lancer automatiquement les tests (#130 et #134, par @mvergez)
@@ -35,8 +36,9 @@
 
 Si vous mettez à jour le module :
 
+* Les exports définis comme "Public" ont désormais leur API accessible de manière ouverte sans authentification. C'est donc le cas votre export SINP, si vous aviez gardé cet export public créé par défaut lors de l'installation du module
 * Si vous les aviez surcouché, supprimez les paramètres `export_schedules_dir`, `usr_generated_dirname` et `export_web_url` de la configuration du module
-* La table listant les exports réalisée (`gn_exports.t_exports_logs`) sera automatiquement supprimée
+* La table listant les exports réalisés (`gn_exports.t_exports_logs`) sera automatiquement supprimée
 * Les exports au format SHP seront convertis automatiquement en export au format GPKG. Attention si vous aviez des exports planifiés au format SHP, leur URL changera avec le même nom mais avec l'extension `.gpkg`.
 * Les droits d'accès au module et aux exports ne se basent désormais plus que sur l'action R (read), et non plus E (export).
 * Une colomne permettant d'indiquer le champ d'unicité des vues a été ajoutée dans la table des exports (`gn_exports.t_exports.view_pk_column`). Pour les exports existants, cette colonne est automatiquement remplie avec la valeur de la première colonne des vues exports. Vous pouvez vérifier ou modifier ce champs pour les exports existants.


### PR DESCRIPTION
Depuis la version 1.5.0, les exports définis comme "Public" ont aussi leur API qui est accessible publiquement, de manière ouverte sans authentification.

Cette PR clarifie cela dans la documentation, mais aussi pour ceux qui ont l'export SINP installé par défaut avec le module et défini comme "Public".

Et pour les prochaines installations, cet export créé par défaut, contenant toute la Synthèse du GeoNature n'est plus défini comme public.