### PR TITLE
fix(gitmodules): change URL of a git submodule from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/GeoNature"]
 	path = dependencies/GeoNature
-	url = git@github.com:PnX-SI/GeoNature.git
+	url = https://github.com/PnX-SI/GeoNature.git
 [submodule "dependencies/Utils-Flask-SQLAlchemy"]
 	path = dependencies/Utils-Flask-SQLAlchemy
 	url = https://github.com/PnX-SI/Utils-Flask-SQLAlchemy.git


### PR DESCRIPTION
## DESCRIPTION

Change the URL for the git submodule "dependencies/GeoNature" from `git@github.com/PnX-SI/GeoNature.git` to `https://github.com/PnX-SI/GeoNature.git, so that the command `git submodule update` works properly instead of causing the following error : 

``` 
git@github.com: Permission denied (publickey).
fatal: Impossible de lire le dépôt distant.

Veuillez vérifier que vous avez les droits d'accès
et que le dépôt existe.
fatal: Le clonage de 'git@github.com:PnX-SI/GeoNature.git' dans le chemin de sous-module '/home/geonatureadmin/gn_module_export/dependencies/GeoNature' a échoué
Impossible de cloner 'dependencies/GeoNature'. Réessai prévu
```

## ADDITIONAL INFORMATION

Use the following command, after retrieving the present commit, to repair after a failed git submodule update: `git submodule sync --recursive`.