### PR TITLE
[Hotfix] unused shapely import

### DIFF
--- a/backend/gn_module_export/utils_export.py
+++ b/backend/gn_module_export/utils_export.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from flask import current_app, url_for
 from geoalchemy2.shape import from_shape
-from shapely.geometry import asShape
 
 from werkzeug.exceptions import Forbidden
 


### PR DESCRIPTION
Fix an unused old import of `shapely` that break the export module setup.