### PR TITLE
Update generic_swagger_doc.json double quote "schemes"

### DIFF
--- a/backend/gn_module_export/blueprint.py
+++ b/backend/gn_module_export/blueprint.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import json
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -132,7 +133,7 @@ def swagger_ressources(id_export=None):
         schemes=scheme,
     )
 
-    return Response(swagger_spec)
+    return jsonify(json.loads(swagger_spec))
 
 
 """

--- a/backend/gn_module_export/templates/swagger/generic_swagger_doc.json
+++ b/backend/gn_module_export/templates/swagger/generic_swagger_doc.json
@@ -6,7 +6,7 @@
     "description": "{{export_description}}",
     "license": {
       "name": "{{licence_nom}}",
-      "url": "{{licence_description}}",
+      "url": "{{licence_description}}"
     },
     "contact": {
       "name": "API Support",


### PR DESCRIPTION
Les valeurs dans le tableau de la clé "schemes" se trouvaient encadrées par des simple quotes. |tojson permet de corriger avec des doubles quotes