### PR TITLE
feat(export) : enable to filter an export results with a geom

### DIFF
--- a/backend/gn_module_export/blueprint.py
+++ b/backend/gn_module_export/blueprint.py
@@ -1,5 +1,5 @@
 """
-    Définition des routes du module export
+Définition des routes du module export
 """
 
 import logging

--- a/backend/gn_module_export/blueprint.py
+++ b/backend/gn_module_export/blueprint.py
@@ -235,7 +235,7 @@ def get_one_export_api(id_export):
         filter_n_lo_nom_col=val: Si nom_col fait partie des colonnes
             de la vue et que la colonne est de type numérique
             alors filtre nom_col <= val
-        inwkt=val: Si nom_col fait partie des colonnes
+        geometry=val: Si nom_col fait partie des colonnes
             de la vue et que la colonne est de type geometry
             alors ST_Intersects(nom_col, ST_GeomFromText(val))
     ORDONNANCEMENT :

--- a/backend/gn_module_export/blueprint.py
+++ b/backend/gn_module_export/blueprint.py
@@ -235,6 +235,9 @@ def get_one_export_api(id_export):
         filter_n_lo_nom_col=val: Si nom_col fait partie des colonnes
             de la vue et que la colonne est de type numérique
             alors filtre nom_col <= val
+        inwkt=val: Si nom_col fait partie des colonnes
+            de la vue et que la colonne est de type geometry
+            alors ST_Intersects(nom_col, ST_GeomFromText(val))
     ORDONNANCEMENT :
         orderby: char
             Nom du champ sur lequel baser l'ordonnancement

--- a/backend/gn_module_export/conf_schema_toml.py
+++ b/backend/gn_module_export/conf_schema_toml.py
@@ -1,5 +1,5 @@
 """
-   Spécification du schéma toml des paramètres de configurations
+Spécification du schéma toml des paramètres de configurations
 """
 
 from geonature.utils.env import ROOT_DIR

--- a/backend/gn_module_export/repositories.py
+++ b/backend/gn_module_export/repositories.py
@@ -72,7 +72,7 @@ def generate_swagger_spec(id_export):
         },
         {
             "in": "query",
-            "name": "inwkt",
+            "name": "geometry",
             "type": "array[string]",
             "description": "Permet de retourner les entrées dont la géométrie intersecte avec celle spécifiée dans le paramètre. La géométrie doit être au format WKT (Well-Known Text)."
             + " et les coordonnées de la zone doivent correspondre au SRID de la vue. \n Exemple : POLYGON ((4.833984 41.541478, 14.633789 41.541478, 14.633789 46.437857, 4.833984 46.437857, 4.833984 41.541478))",

--- a/backend/gn_module_export/repositories.py
+++ b/backend/gn_module_export/repositories.py
@@ -1,5 +1,5 @@
 """
-    Module de gestion des exports
+Module de gestion des exports
 """
 
 from geonature.utils.env import DB

--- a/backend/gn_module_export/repositories.py
+++ b/backend/gn_module_export/repositories.py
@@ -70,6 +70,13 @@ def generate_swagger_spec(id_export):
             "type": "varchar",
             "description": "Nom d'un champ de la vue qui sera utilisé comme variable de tri. Une mention au sens du tri peut être ajoutée en utilisant la syntaxe suivante : nom_col[:ASC|DESC]",
         },
+        {
+            "in": "query",
+            "name": "inwkt",
+            "type": "array[string]",
+            "description": "Permet de retourner les entrées dont la géométrie intersecte avec celle spécifiée dans le paramètre. La géométrie doit être au format WKT (Well-Known Text)."
+            + " et les coordonnées de la zone doivent correspondre au SRID de la vue. \n Exemple : POLYGON ((4.833984 41.541478, 14.633789 41.541478, 14.633789 46.437857, 4.833984 46.437857, 4.833984 41.541478))",
+        },
     ]
 
     if not export.public:

--- a/backend/gn_module_export/utils_export.py
+++ b/backend/gn_module_export/utils_export.py
@@ -1,5 +1,5 @@
 """
-    Fonctions permettant la génération des fichiers d'export
+Fonctions permettant la génération des fichiers d'export
 """
 
 from datetime import datetime, timedelta


### PR DESCRIPTION
Depends on https://github.com/PnX-SI/Utils-Flask-SQLAlchemy-Geo/pull/35

TODO

- [x] Renommer `inwkt` en `geometry`
- [x] Mettre à jour documentation
```
geometry
array[string]
(query) 
Searches for occurrences inside a polygon described in Well Known Text (WKT) format. Only POLYGON and MULTIPOLYGON are accepted WKT types.
```